### PR TITLE
[semver: major]bump circleci go orb to latest, remove go mod cache

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,4 +10,4 @@ display:
 orbs:
   aws-cli: circleci/aws-cli@2.0.2
   aws-ecr: circleci/aws-ecr@6.15.3
-  go: circleci/go@1.6.0
+  go: circleci/go@1.7.0

--- a/src/jobs/go-mod-ginkgo.yml
+++ b/src/jobs/go-mod-ginkgo.yml
@@ -48,9 +48,7 @@ steps:
   - run:
       name: setup golang
       command: goenv version
-  - go/load-cache
   - go/mod-download
-  - go/save-cache
   - ginkgo:
       environment: << parameters.environment >>
       golang_version: << parameters.golang_version >>


### PR DESCRIPTION
Removing go-mod cache saving and loading as its currently causing issues with our runners.  
Bump version to latest CircleCi Orb while here.
Calling a major release since the cache changes might have an impact on build times but checking both research-relay and dept-health-reporting repo I noticed previously it would save a cache of [32 Bytes ](https://app.circleci.com/pipelines/github/myhelix/dept-health-reporting/179/workflows/8412c5ff-8fb7-44f4-8c9e-b63322c2e4b1/jobs/1811/parallel-runs/0/steps/0-105)(which indicates to me it was caching nothing) but now its trying to actually save a cache of [100+MB ](https://app.circleci.com/pipelines/github/myhelix/dept-health-reporting/187/workflows/4c9ce8a0-6742-48b0-bc79-9e906b2804c4/jobs/1936/parallel-runs/0/steps/0-105)and now it's failing.   I cant explain why suddenly its actually saving cache, possibly a change on CircleCI side but it seems we never really used go-mod caching offered by CircleCi.