### PR TITLE
[semver:major] add parallelism and create new test-parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # orb.yml is "packed" from source, and not published directly from the repository.
 orb.yml
+.idea

--- a/src/commands/test-parallel.yml
+++ b/src/commands/test-parallel.yml
@@ -1,0 +1,53 @@
+description: >
+  Run tests
+parameters:
+  test_type:
+    description: The test type to run.
+    type: enum
+    enum: ['acceptance', 'unit']
+  ginkgo_params:
+    type: string
+    default: -failFast  -keepGoing  -nodes 4  -r  -randomizeAllSpecs  -randomizeSuites  -timeout 5m
+    description: "flags to add to the ginkgo command (see ginkgo -h)"
+
+steps:
+  - aws-cli/setup
+  - run:
+      name: install ginkgo
+      command: |
+        if [ -z "$(which ginkgo)" ]; then
+          echo "Installing ginkgo"
+          go get github.com/onsi/ginkgo/ginkgo
+        fi
+  - run:
+      name: Act as AWS admin
+      command: |
+        # Manually assume role to get temporary aws credentials
+        assume_creds=$(aws sts assume-role --role-session-name "${CIRCLE_USERNAME:-bot}-circleci" --role-arn arn:aws:iam::$AWS_ACCOUNT_ID:role/$ASSUME_AWS_PROFILE)
+        echo "export AWS_ACCESS_KEY_ID=$(echo $assume_creds | jq -r .Credentials.AccessKeyId)" >> $BASH_ENV
+        echo "export AWS_SECRET_ACCESS_KEY=$(echo $assume_creds | jq -r .Credentials.SecretAccessKey)" >> $BASH_ENV
+        echo "export AWS_SESSION_TOKEN=$(echo $assume_creds | jq -r .Credentials.SessionToken)" >> $BASH_ENV
+        echo "export AWS_SDK_LOAD_CONFIG=1" >> $BASH_ENV
+  - run:
+      name: setup env
+      command: |
+        echo "export GO_ENV=${ENVIRONMENT}" >> $BASH_ENV
+        echo "export PROJECT=${PROJECT_NAME:=$CIRCLE_PROJECT_REPONAME}" >> $BASH_ENV
+  - run:
+      name: list env
+      command: env
+  - run:
+      name: run ginkgo
+      environment:
+        TEST_TYPE: <<parameters.test_type>>
+      command: |
+        EXTRA_PARMS=""
+        if [[ 'unit' == "$TEST_TYPE" ]]; then
+          echo "Running all tests except acceptance tests"
+          EXTRA_PARAMS="-cover -coverprofile cover.out -skipPackage acceptance"
+        else
+          echo "Running acceptance tests"
+          EXTRA_PARAMS="acceptance"
+        fi
+        echo $(go list ./... | sed -e "s|github.com/myhelix/$CIRCLE_PROJECT_REPONAME/||" | circleci tests split --split-by=timings --timings-type=classname)
+        ginkgo << parameters.ginkgo_params >> $EXTRA_PARAMS $(go list ./... | sed -e "s|github.com/myhelix/$CIRCLE_PROJECT_REPONAME/||" | circleci tests split --split-by=timings)

--- a/src/commands/test-parallel.yml
+++ b/src/commands/test-parallel.yml
@@ -49,5 +49,5 @@ steps:
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"
         fi
-        echo $(go list ./... | sed -e "s|github.com/myhelix/$CIRCLE_PROJECT_REPONAME/||" | circleci tests split --split-by=timings --timings-type=classname)
-        ginkgo << parameters.ginkgo_params >> $EXTRA_PARAMS $(go list ./... | sed -e "s|github.com/myhelix/$CIRCLE_PROJECT_REPONAME/||" | circleci tests split --split-by=timings)
+        echo $(go list -f='{{.Dir}}' ./... | circleci tests split --split-by=timings --timings-type=classname)
+        ginkgo << parameters.ginkgo_params >> $EXTRA_PARAMS $(go list -f='{{.Dir}}' ./... | circleci tests split --split-by=timings)

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -28,6 +28,35 @@ workflows:
               only: /^feature/.*/
 ```
 
+## golang/test-parallel
+
+Run unit or acceptance tests with ginkgo.  Allow to set parallelism and split ginkgo test
+
+_Note_ this will install the latest version of ginkgo,
+for services that depends on hss, see golang/glide-ginkgo
+
+
+```yaml
+workflows:
+  build:
+    jobs:
+      - golang/test:
+          name: "Test"
+          context: ci
+          test_type: unit
+          parallelism: 10
+
+      - golang/test:
+          context: development
+          name: "Dev Acceptance Test"
+          test_type: acceptance
+          requires:
+            - "Deploy cdk: Development"
+          filters:
+            branches:
+              only: /^feature/.*/
+```
+
 ## golang/glide-ginkgo
 
 Run unit or acceptance tests on a runner with ginkgo.

--- a/src/jobs/test-parallel.yml
+++ b/src/jobs/test-parallel.yml
@@ -1,0 +1,49 @@
+description: >
+  Run ginkgo tests on a standard circleci build agent
+
+parameters:
+  golang_version_short:
+    description: >
+      The version of the golang executor to use.
+      NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
+      While we don't have a direct dependency here, other steps do.
+    type: enum
+    enum: ['1.13', '1.14', '1.15', '1.16']
+    default: '1.15'
+  test_type:
+    description: The test type to run.
+    type: enum
+    enum: ['acceptance', 'unit']
+  project_name:
+    type: string
+    description: "Project name, must match github repo name"
+    default: ""
+  ginkgo_params:
+    type: string
+    default: -failFast  -keepGoing  -nodes 4  -r  -randomizeAllSpecs  -randomizeSuites  -timeout 5m
+    description: "flags to add to the ginkgo command (see ginkgo -h)"
+  parallelism:
+    type: integer
+    default: 1
+    description: "Set the parallelism for the job"
+executor:
+  name: default
+  golang_version_short: << parameters.golang_version_short >>
+
+resource_class: xlarge
+
+environment:
+  PROJECT_NAME: << parameters.project_name >>
+
+parallelism: << parameters.parallelism >>
+
+steps:
+  - checkout
+  - go/load-cache
+  - go/mod-download
+  - go/save-cache
+  - test-parallel:
+      test_type: << parameters.test_type >>
+      ginkgo_params: << parameters.ginkgo_params >>
+  - store_test_results:
+      path: test-results


### PR DESCRIPTION
I tried upgrading the Patient repo to use golang 1.16 and CircleCi started timing out after 10min as the job was taking too long.  So I started looking how we can use parallelism and this is the result.
I am not super proud of the sed and would like an extra 👁️ on that as I am worried it could be fragile and open to a better way of doing that.  But I pushed the dev in patient and it speedup the test, test going from 6min to 1min.