### PR TITLE
[semver:major] Add ginkgo v2

### DIFF
--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -1,0 +1,67 @@
+description: >
+  Install ginkgo if necessary and run tests
+
+parameters:
+  environment:
+    description: what runner to run on
+    type: string
+  golang_version:
+    type: enum
+    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19']
+    description: >
+      NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
+  org:
+    type: string
+    default: myhelix
+  project_name:
+    type: string
+    description: "Project name, must match github repo name"
+  test_type:
+    description: The test type to run.
+    type: enum
+    enum: ['acceptance', 'unit']
+  ginkgo_params:
+    type: string
+    default: -fail-fast  -keep-going  -nodes 4  -r  -randomize-all-specs  -randomize-suites  -timeout 5m
+    description: "flags to add to the ginkgo command (see ginkgo -h)"
+  go_env:
+    type: string
+    description: "Set the environment Variable GO_ENV"
+    default: ""
+
+steps:
+  - run:
+      name: determine GO_ENV
+      command: |
+        if [[ -z "<< parameters.go_env >>" ]]; then
+          echo "export GO_ENV=<< parameters.environment >>" >> $BASH_ENV
+        else
+          echo "export GO_ENV=<< parameters.go_env >>" >> $BASH_ENV
+        fi
+  - run:
+      name: setup golang
+      command: goenv version
+  - run:
+      name: install ginkgo
+      command: |
+        if [ -z "$(which ginkgo)" ]; then
+          echo "Installing ginkgo"
+          GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
+        fi
+  - run:
+      name: run ginkgo
+      environment:
+        ENVIRONMENT: << parameters.environment >>
+        GOENV_VERSION: << parameters.golang_version >>
+        PROJECT_NAME: << parameters.project_name >>
+        TEST_TYPE: <<parameters.test_type>>
+      command: |
+        EXTRA_PARMS=""
+        if [[ 'unit' == "$TEST_TYPE" ]]; then
+          echo "Running all tests except acceptance tests"
+          EXTRA_PARAMS="-cover -coverprofile cover.out -skipPackage acceptance"
+        else
+          echo "Running acceptance tests"
+          EXTRA_PARAMS="acceptance"
+        fi
+        ginkgo << parameters.ginkgo_params >> $EXTRA_PARAMS

--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -44,9 +44,11 @@ steps:
   - run:
       name: install ginkgo
       command: |
+        which ginkgo
+        goenv version
         if [ -z "$(which ginkgo)" ]; then
           echo "Installing ginkgo"
-          GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
+          GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo@latest
         fi
   - run:
       name: run ginkgo
@@ -64,4 +66,5 @@ steps:
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"
         fi
+        ginkgo version
         ginkgo << parameters.ginkgo_params >> $EXTRA_PARAMS

--- a/src/jobs/go-mod-ginkgo-v2.yml
+++ b/src/jobs/go-mod-ginkgo-v2.yml
@@ -26,7 +26,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: -failFast  -keepGoing  -nodes 4  -r  -randomizeAllSpecs  -randomizeSuites  -timeout 5m
+    default: -fail-fast  -keep-going  -nodes 4  -r  -randomize-all-specs  -randomize-suites  -timeout 5m
     description: "flags to add to the ginkgo command (see ginkgo -h)"
 
 environment:
@@ -43,19 +43,25 @@ steps:
   - sanitize-identity
   - checkout
   - run:
-      name: Set Default GO_ENV
-      command: echo 'export GO_ENV=${GO_ENV:-$ENVIRONMENT}' >> $BASH_ENV
+      name: Set Default GO_ENV and Shims
+      command: |
+        echo 'export GO_ENV=${GO_ENV:-$ENVIRONMENT}' >> $BASH_ENV
+        echo 'export GOENV_ROOT="$HOME/.goenv"' >> $BASH_ENV
+        echo 'export PATH="$GOENV_ROOT/bin:$PATH"' >> $BASH_ENV
+        echo 'export PATH="$GOENV_ROOT/shims:$PATH"' >> $BASH_ENV
   - run:
       name: Set AWS_REGION
       command: echo 'export AWS_REGION=${AWS_REGION:-us-east-1}' >> $BASH_ENV
   - run:
-      name: setup golang
-      command: goenv version
+      name: print golang version
+      command: |
+        echo $GOENV_VERSION
+        go version
   - go/mod-download
   - run:
       name: go mod vendor
       command: go mod vendor
-  - ginkgo:
+  - ginkgo-v2:
       environment: << parameters.environment >>
       golang_version: << parameters.golang_version >>
       project_name: << parameters.project_name >>

--- a/src/jobs/go-mod-ginkgo.yml
+++ b/src/jobs/go-mod-ginkgo.yml
@@ -55,7 +55,7 @@ steps:
   - run:
       name: go mod vendor
       command: go mod vendor
-  - ginkgo:
+  - ginkgo-v2:
       environment: << parameters.environment >>
       golang_version: << parameters.golang_version >>
       project_name: << parameters.project_name >>


### PR DESCRIPTION
This add support for Ginko V2 but also addresses a problem I saw when using goenv to set golang versions.  Turns out due to the shims not being defined in the $PATH the Shell would default to the OS installed golang install (which for the runner is 1.15) and also whatever version of Ginkgo was installed with it.

This change should fix that problem by adding `shim` to your path. That combined with setting `GOENV_VERSION` should result in goenv having selected the correct go version.