### PR TITLE
replace devops with engineering team as devops team is no more

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @myhelix/engineering
+* @ZuhaibSiddiqueHelix @myhelix/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @yeaji-helix @myhelix/devops-team
+* @myhelix/engineering


### PR DESCRIPTION
Change code owner to reflect that all of @myhelix/engineering is the owner of this project