### PR TITLE
[semver:patch] Fix bug with install Gingko

### DIFF
--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -45,11 +45,9 @@ steps:
       name: install ginkgo
       command: |
         which ginkgo
+        echo "Installing ginkgo"
+        GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo@latest
         goenv version
-        if [ -z "$(which ginkgo)" ]; then
-          echo "Installing ginkgo"
-          GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo@latest
-        fi
   - run:
       name: run ginkgo
       environment:

--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -22,7 +22,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: -fail-fast  -keep-going  -nodes 4  -r  -randomize-all-specs  -randomize-suites  -timeout 5m
+    default: -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
     description: "flags to add to the ginkgo command (see ginkgo -h)"
   go_env:
     type: string

--- a/src/jobs/go-mod-ginkgo-v2.yml
+++ b/src/jobs/go-mod-ginkgo-v2.yml
@@ -26,7 +26,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: -fail-fast  -keep-going  -nodes 4  -r  -randomize-all-specs  -randomize-suites  -timeout 5m
+    default: -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
     description: "flags to add to the ginkgo command (see ginkgo -h)"
 
 environment:


### PR DESCRIPTION
`which ginkgo` seems to still find the old Ginkgo binary, so, lets just install it every time.  Also `-randomize-all-specs` was removed and renamed as `-randomize-all`