### PR TITLE
Nka/add go 1.17

### DIFF
--- a/src/commands/ginkgo.yml
+++ b/src/commands/ginkgo.yml
@@ -56,6 +56,7 @@ steps:
         PROJECT_NAME: << parameters.project_name >>
         TEST_TYPE: <<parameters.test_type>>
       command: |
+        mkdir test-results
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
@@ -64,4 +65,5 @@ steps:
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"
         fi
+        ginkgo version
         ginkgo << parameters.ginkgo_params >> $EXTRA_PARAMS

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.13', '1.14', '1.15', '1.16', '1.18', '1.19']
+    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19']
 
 docker:
   - image: cimg/go:<< parameters.golang_version_short >>

--- a/src/jobs/go-mod-ginkgo.yml
+++ b/src/jobs/go-mod-ginkgo.yml
@@ -26,7 +26,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: -failFast  -keepGoing  -nodes 4  -r  -randomizeAllSpecs  -randomizeSuites  -timeout 5m
+    default: --output-dir=test-results/ -failFast  -keepGoing  -nodes 4  -r  -randomizeAllSpecs  -randomizeSuites  -timeout 5m
     description: "flags to add to the ginkgo command (see ginkgo -h)"
 
 environment:
@@ -43,14 +43,20 @@ steps:
   - sanitize-identity
   - checkout
   - run:
-      name: Set Default GO_ENV
-      command: echo 'export GO_ENV=${GO_ENV:-$ENVIRONMENT}' >> $BASH_ENV
+      name: Set Default GO_ENV and Shims
+      command: |
+        echo 'export GO_ENV=${GO_ENV:-$ENVIRONMENT}' >> $BASH_ENV
+        echo 'export GOENV_ROOT="$HOME/.goenv"' >> $BASH_ENV
+        echo 'export PATH="$GOENV_ROOT/bin:$PATH"' >> $BASH_ENV
+        echo 'export PATH="$GOENV_ROOT/shims:$PATH"' >> $BASH_ENV
   - run:
       name: Set AWS_REGION
       command: echo 'export AWS_REGION=${AWS_REGION:-us-east-1}' >> $BASH_ENV
   - run:
-      name: setup golang
-      command: goenv version
+      name: print golang version
+      command: |
+        echo $GOENV_VERSION
+        go version
   - go/mod-download
   - run:
       name: go mod vendor
@@ -63,3 +69,5 @@ steps:
       test_type: <<parameters.test_type>>
       ginkgo_params: << parameters.ginkgo_params >>
       go_env: <<parameters.go_env>>
+  - store_test_results:
+      path: test-results


### PR DESCRIPTION
## Background
The circleCI test and acceptance tests jobs in research-relay fail with the following despite the go version being set to 1.17.
```bash
# golang.org/x/sys/unix
vendor/golang.org/x/sys/unix/syscall.go:83:28: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)
vendor/golang.org/x/sys/unix/syscall_linux.go:2270:21: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)
vendor/golang.org/x/sys/unix/syscall_unix.go:118:19: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)
vendor/golang.org/x/sys/unix/sysvshm_unix.go:33:19: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)
```

## What
This PR adds support for multiple go versions to the golang/go-mod-ginkgo workflow and fixes the storage of test results

## Summary
1. add go 1.17 to executor defaults
2. adding go shim to `golang/go-mod-ginkgo` so go version selections will be used
3. Adding support junit tests