### PR TITLE
Nka/ginkgo v2 fix skip package flags

### DIFF
--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -56,11 +56,13 @@ steps:
         PROJECT_NAME: << parameters.project_name >>
         TEST_TYPE: <<parameters.test_type>>
       command: |
-        mkdir test-results
+        if ! [ -d test-results ]; then
+            mkdir test-results
+        fi
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="-cover -coverprofile cover.out -skipPackage acceptance"
+          EXTRA_PARAMS="-cover -coverprofile cover.out -skip-package acceptance"
         else
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"

--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -60,7 +60,7 @@ steps:
           rm -rf test-results
         fi
         mkdir test-results
-        
+
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"

--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -56,9 +56,11 @@ steps:
         PROJECT_NAME: << parameters.project_name >>
         TEST_TYPE: <<parameters.test_type>>
       command: |
-        if ! [ -d test-results ]; then
-            mkdir test-results
+        if [ -d test-results ]; then
+          rm -rf test-results
         fi
+        mkdir test-results
+        
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"

--- a/src/commands/test-parallel-v2.yml
+++ b/src/commands/test-parallel-v2.yml
@@ -41,11 +41,13 @@ steps:
       environment:
         TEST_TYPE: <<parameters.test_type>>
       command: |
-        mkdir test-results
+        if ! [ -d test-results ]; then
+            mkdir test-results
+        fi
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="-cover -coverprofile cover.out -skipPackage acceptance"
+          EXTRA_PARAMS="-cover -coverprofile cover.out -skip-package acceptance"
         else
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"

--- a/src/commands/test-parallel-v2.yml
+++ b/src/commands/test-parallel-v2.yml
@@ -45,7 +45,7 @@ steps:
           rm -rf test-results
         fi
         mkdir test-results
-        
+
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"

--- a/src/commands/test-parallel-v2.yml
+++ b/src/commands/test-parallel-v2.yml
@@ -41,9 +41,11 @@ steps:
       environment:
         TEST_TYPE: <<parameters.test_type>>
       command: |
-        if ! [ -d test-results ]; then
-            mkdir test-results
+        if [ -d test-results ]; then
+          rm -rf test-results
         fi
+        mkdir test-results
+        
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"

--- a/src/commands/test-v2.yml
+++ b/src/commands/test-v2.yml
@@ -46,7 +46,7 @@ steps:
           rm -rf test-results
         fi
         mkdir test-results
-        
+
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
           EXTRA_PARAMS="-cover -coverprofile cover.out -skip-package acceptance"

--- a/src/commands/test-v2.yml
+++ b/src/commands/test-v2.yml
@@ -42,9 +42,11 @@ steps:
         TEST_TYPE: <<parameters.test_type>>
       command: |
         EXTRA_PARMS=""
-        if ! [ -d test-results ]; then
-            mkdir test-results
+        if [ -d test-results ]; then
+          rm -rf test-results
         fi
+        mkdir test-results
+        
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
           EXTRA_PARAMS="-cover -coverprofile cover.out -skip-package acceptance"

--- a/src/commands/test-v2.yml
+++ b/src/commands/test-v2.yml
@@ -42,7 +42,9 @@ steps:
         TEST_TYPE: <<parameters.test_type>>
       command: |
         EXTRA_PARMS=""
-        mkdir test-results
+        if ! [ -d test-results ]; then
+            mkdir test-results
+        fi
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
           EXTRA_PARAMS="-cover -coverprofile cover.out -skip-package acceptance"


### PR DESCRIPTION
## Background 
ginkgo-v2 builds are failing with `mkdir: cannot create directory ‘test-results’: File exists`. The build artifacts seem to persistent between runs.

## What
Perform a limited cleanup every run of the test-results directory

## Summary
- replaced the deprecated `-skipPackage` with `-skip-package`
- Added conditional cleanup of test-results directory