### PR TITLE
Add 1.17 to default executor

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.13', '1.14', '1.15', '1.16', '1.18', '1.19']
+    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19']
 
 docker:
   - image: cimg/go:<< parameters.golang_version_short >>


### PR DESCRIPTION
Adding 1.17 to default executor. Pretty much every usage already theoretically supports it: https://github.com/myhelix/golang-orb/pull/37/files

However, CircleCI does line by line validation and trips up here before using the override in the next line: https://github.com/myhelix/golang-orb/blob/main/src/jobs/lint.yml#L20

Error: https://app.circleci.com/pipelines/github/myhelix/accessioning/1245