### PR TITLE
[semver:minor] Add persist_to_workspace to go-mod-ginkgo-v2

### DIFF
--- a/src/jobs/go-mod-ginkgo-v2.yml
+++ b/src/jobs/go-mod-ginkgo-v2.yml
@@ -71,3 +71,6 @@ steps:
       go_env: <<parameters.go_env>>
   - store_test_results:
       path: test-results
+  - persist_to_workspace:
+      paths:
+        - test-results

--- a/src/jobs/go-mod-ginkgo-v2.yml
+++ b/src/jobs/go-mod-ginkgo-v2.yml
@@ -28,6 +28,14 @@ parameters:
     type: string
     default: --junit-report=report.xml --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
     description: "flags to add to the ginkgo command (see ginkgo -h)"
+  persist_results:
+    description: "Whether or not to persist test results to the workspace"
+    default: false
+    type: boolean
+  persist_at:
+    description: "Where should we persist the workspace"
+    default: "/tmp/workspace/"
+    type: string
 
 environment:
   GOENV_VERSION: << parameters.golang_version >>
@@ -71,6 +79,10 @@ steps:
       go_env: <<parameters.go_env>>
   - store_test_results:
       path: test-results
-  - persist_to_workspace:
-      paths:
-        - test-results
+  - when:
+      condition: <<parameters.persist_results>>
+      steps:
+        - persist_to_workspace:
+            root: << parameters.persist_at >>
+            paths:
+              - test-results

--- a/src/jobs/go-mod-ginkgo-v2.yml
+++ b/src/jobs/go-mod-ginkgo-v2.yml
@@ -26,7 +26,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: --junit-report=report.xml --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
+    default: --junit-report=report.xml --json-report=report.json --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
     description: "flags to add to the ginkgo command (see ginkgo -h)"
   persist_results:
     description: "Whether or not to persist test results to the workspace"

--- a/src/jobs/go-mod-ginkgo-v2.yml
+++ b/src/jobs/go-mod-ginkgo-v2.yml
@@ -82,6 +82,11 @@ steps:
   - when:
       condition: <<parameters.persist_results>>
       steps:
+        - run:
+            name: Move files to workspace
+            command: |
+              mkdir -p << parameters.persist_at >>
+              mv test-results << parameters.persist_at >>/
         - persist_to_workspace:
             root: << parameters.persist_at >>
             paths:


### PR DESCRIPTION
[CHA-3030]

Save test results to workspace to make them available to downstream jobs. Also add `--json-report` to default flags (easier to consume than XML).

[CHA-3030]: https://myhelix.atlassian.net/browse/CHA-3030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ