### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ZuhaibSiddiqueHelix @myhelix/engineering
+* @ZuhaibSiddiqueHelix @myhelix/cloud


### PR DESCRIPTION
Set CODEOWNERS to Cloud team instead of myhelix/engineering to avoid mass emailing all of engineering with PR update notification emails.