### PR TITLE
[semver:minor] Sets `setup_remote_docker` version to default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ parameters:
       This value is automatically adjusted by the "trigger-integration-tests-workflow" job to correspond with the specific version created by the commit and should not be edited.
       A "dev:alpha" version must exist for the initial pipeline run.
     type: string
-    default: "3"
+    default: "dev:alpha"
 
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ parameters:
       This value is automatically adjusted by the "trigger-integration-tests-workflow" job to correspond with the specific version created by the commit and should not be edited.
       A "dev:alpha" version must exist for the initial pipeline run.
     type: string
-    default: "dev:alpha"
+    default: "3"
 
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.

--- a/src/jobs/glide-build-publish.yml
+++ b/src/jobs/glide-build-publish.yml
@@ -42,7 +42,7 @@ steps:
   - checkout
   - assume_oidc_role
   - setup_remote_docker:
-      version: 19.03.13
+      version: default
   - glide-install
   - run:
       name: go build

--- a/src/jobs/go-mod-build-publish.yml
+++ b/src/jobs/go-mod-build-publish.yml
@@ -42,7 +42,7 @@ steps:
   - checkout
   - assume_oidc_role
   - setup_remote_docker:
-      version: 19.03.13
+      version: default
   - run:
       name: go build
       command: |


### PR DESCRIPTION
### Background
CircleCI started deprecating fixed versions of Docker at `setup_remote_docker` job previous to v23.
- https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176

Failure at accessioning due to this:
![image](https://github.com/myhelix/golang-orb/assets/98179757/0bf06aec-b422-419b-9c7f-e3122bf2c03f)


### What
Sets `setup_remote_docker` to use default version (currently Docker v24).