### PR TITLE
 add assume_oidc_role to go-mod-ginkgo-v2-labels.

### DIFF
--- a/src/jobs/go-mod-ginkgo-v2-labels.yml
+++ b/src/jobs/go-mod-ginkgo-v2-labels.yml
@@ -47,6 +47,7 @@ working_directory: /home/circleci/go/<< parameters.golang_version >>/src/github.
 steps:
   - sanitize-identity
   - checkout
+  - assume_oidc_role
   - run:
       name: Set Default GO_ENV and Shims
       command: |


### PR DESCRIPTION
add it to another job. 

(only used in email-sub for now)