### PR TITLE
[semver:minor] - adding 1.20 and 1.21 to enum options

### DIFF
--- a/src/commands/ginkgo-v2-labels.yml
+++ b/src/commands/ginkgo-v2-labels.yml
@@ -22,7 +22,7 @@ parameters:
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
     type: enum
-    enum: ["1.18", "1.19"]
+    enum: ["1.18", "1.19", "1.20", "1.21"]
   org:
     type: string
     default: "myhelix"


### PR DESCRIPTION
⚠️ auto-merge enabled ⚠️ 

## Background
#69 missed including 1.20 and 1.21 in the enums for the ginkgo-v2-labels job