### PR TITLE
[semver:minor] - limit ginkgo to 4 parallel builds

### DIFF
--- a/src/commands/ginkgo-v2-labels.yml
+++ b/src/commands/ginkgo-v2-labels.yml
@@ -13,7 +13,7 @@ parameters:
   ginkgo_params:
     description: "command line flags to add to when the ginkgo command is run (see ginkgo -h)"
     type: string
-    default: --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m -cover -coverprofile cover.out
+    default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --fail-fast --keep-going --race --trace --junit-report=report.xml --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s --cover --coverprofile=cover.out
   go_env:
     description: "Set the environment Variable GO_ENV"
     type: string

--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -22,7 +22,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
+    default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --fail-fast --keep-going --race --trace --junit-report=report.xml --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s
     description: "flags to add to the ginkgo command (see ginkgo -h)"
   go_env:
     type: string
@@ -62,7 +62,7 @@ steps:
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="-cover -coverprofile cover.out -skip-package acceptance"
+          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance"
         else
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"

--- a/src/commands/test-parallel-v2.yml
+++ b/src/commands/test-parallel-v2.yml
@@ -7,7 +7,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
+    default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --fail-fast --keep-going --race --trace --junit-report=report.xml --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s
     description: "flags to add to the ginkgo command (see ginkgo -h)"
 
 steps:
@@ -47,7 +47,7 @@ steps:
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="-cover -coverprofile cover.out -skip-package acceptance"
+          EXTRA_PARAMS="--cover --coverprofile=cover.out --skip-package=acceptance"
         else
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"

--- a/src/commands/test-v2.yml
+++ b/src/commands/test-v2.yml
@@ -7,7 +7,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: --junit-report=report.xml --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
+    default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --fail-fast --keep-going --race --trace --junit-report=report.xml --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s
     description: "flags to add to the ginkgo command (see ginkgo -h)"
 
 steps:
@@ -47,7 +47,7 @@ steps:
 
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="-cover -coverprofile cover.out -skip-package acceptance"
+          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance"
         else
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"

--- a/src/jobs/go-mod-ginkgo-v2-labels.yml
+++ b/src/jobs/go-mod-ginkgo-v2-labels.yml
@@ -13,7 +13,7 @@ parameters:
   ginkgo_params:
     description: "command line flags to add to when the ginkgo command is run (see ginkgo -h)"
     type: string
-    default: --junit-report=report.xml --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
+    default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --fail-fast --keep-going --race --trace --junit-report=report.xml --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s --cover --coverprofile=cover.out
   go_env:
     description: "Set the environment Variable GO_ENV"
     type: string

--- a/src/jobs/go-mod-ginkgo-v2-with-oidc.yml
+++ b/src/jobs/go-mod-ginkgo-v2-with-oidc.yml
@@ -26,7 +26,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: --junit-report=report.xml --json-report=report.json --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
+    default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --fail-fast --keep-going --race --trace --junit-report=report.xml --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s
     description: "flags to add to the ginkgo command (see ginkgo -h)"
   persist_results:
     description: "Whether or not to persist test results to the workspace"

--- a/src/jobs/go-mod-ginkgo-v2.yml
+++ b/src/jobs/go-mod-ginkgo-v2.yml
@@ -26,7 +26,7 @@ parameters:
     enum: ['acceptance', 'unit']
   ginkgo_params:
     type: string
-    default: --junit-report=report.xml --json-report=report.json --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
+    default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --fail-fast --keep-going --race --trace --junit-report=report.xml --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s
     description: "flags to add to the ginkgo command (see ginkgo -h)"
   persist_results:
     description: "Whether or not to persist test results to the workspace"

--- a/src/jobs/test-v2.yml
+++ b/src/jobs/test-v2.yml
@@ -20,7 +20,7 @@ parameters:
     default: ""
   ginkgo_params:
     type: string
-    default: --junit-report=report.xml --output-dir=test-results/ -fail-fast  -keep-going  -nodes 4  -r  -randomize-all  -randomize-suites  -timeout 5m
+    default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --fail-fast --keep-going --race --trace --junit-report=report.xml --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s
     description: "flags to add to the ginkgo command (see ginkgo -h)"
   resource_class:
     default: xlarge


### PR DESCRIPTION
- Prevent OOM issues and high CPU usage
- Clean up ginkgo params to be consistent with official documentation