### PR TITLE
ET-1251 | add golang 1.22 and 1.23 to the orb enums

### DIFF
--- a/src/commands/assume_oidc_role.yml
+++ b/src/commands/assume_oidc_role.yml
@@ -6,4 +6,3 @@ steps:
       profile-name: "default"
       role-arn: "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ASSUME_AWS_PROFILE}"
       role-session-name: ${CIRCLE_WORKFLOW_ID}
-

--- a/src/commands/ginkgo-v2-labels.yml
+++ b/src/commands/ginkgo-v2-labels.yml
@@ -22,7 +22,7 @@ parameters:
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
     type: enum
-    enum: ["1.18", "1.19", "1.20", "1.21"]
+    enum: ["1.18", "1.19", "1.20", "1.21", "1.22", "1.23"]
   org:
     type: string
     default: "myhelix"

--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
   golang_version:
     type: enum
-    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
   org:

--- a/src/commands/ginkgo.yml
+++ b/src/commands/ginkgo.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
   golang_version:
     type: enum
-    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
   org:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
 
 docker:
   - image: cimg/go:<< parameters.golang_version_short >>

--- a/src/jobs/ginkgo.yml
+++ b/src/jobs/ginkgo.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
   golang_version:
     type: enum
-    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
   org:

--- a/src/jobs/glide-build-publish.yml
+++ b/src/jobs/glide-build-publish.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
   org:
     type: string
     default: myhelix

--- a/src/jobs/glide-ginkgo.yml
+++ b/src/jobs/glide-ginkgo.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
   golang_version:
     type: enum
-    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
   org:

--- a/src/jobs/go-mod-build-publish.yml
+++ b/src/jobs/go-mod-build-publish.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
   org:
     type: string
     default: myhelix

--- a/src/jobs/go-mod-ginkgo-v2-labels.yml
+++ b/src/jobs/go-mod-ginkgo-v2-labels.yml
@@ -22,7 +22,7 @@ parameters:
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
     type: enum
-    enum: ['1.18', '1.19', '1.20', '1.21']
+    enum: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
   org:
     type: string
     default: "myhelix"

--- a/src/jobs/go-mod-ginkgo-v2-with-oidc.yml
+++ b/src/jobs/go-mod-ginkgo-v2-with-oidc.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
   golang_version:
     type: enum
-    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
   go_env:

--- a/src/jobs/go-mod-ginkgo-v2.yml
+++ b/src/jobs/go-mod-ginkgo-v2.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
   golang_version:
     type: enum
-    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
   go_env:

--- a/src/jobs/go-mod-ginkgo.yml
+++ b/src/jobs/go-mod-ginkgo.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
   golang_version:
     type: enum
-    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
   go_env:

--- a/src/jobs/goose-up.yml
+++ b/src/jobs/goose-up.yml
@@ -6,7 +6,7 @@ parameters:
     type: string
   golang_version:
     type: enum
-    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13.15', '1.14.15', '1.15.10', '1.16.2', '1.16.10', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     description: >
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
   org:

--- a/src/jobs/gox-build.yml
+++ b/src/jobs/gox-build.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     default: '1.15'
   org:
     type: string

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
   org:
     type: string
     default: myhelix

--- a/src/jobs/test-parallel.yml
+++ b/src/jobs/test-parallel.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     default: '1.15'
   test_type:
     description: The test type to run.

--- a/src/jobs/test-v2.yml
+++ b/src/jobs/test-v2.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.18', '1.19', '1.20', '1.21']
+    enum: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     default: '1.18'
   test_type:
     description: The test type to run.

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -8,7 +8,7 @@ parameters:
       NOTE these are installed by https://github.com/myhelix/circleci-runner/blob/master/lib/circleci-runner-stack.ts#L152..L156
       While we don't have a direct dependency here, other steps do.
     type: enum
-    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
+    enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     default: '1.15'
   test_type:
     description: The test type to run.


### PR DESCRIPTION
[ET-1251]

[ET-1251]: https://myhelix.atlassian.net/browse/ET-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ