### PR TITLE
[semver:minor] - Prevent version mismatch due to implicit golang versions

### DIFF
--- a/src/jobs/gox-build.yml
+++ b/src/jobs/gox-build.yml
@@ -9,7 +9,6 @@ parameters:
       While we don't have a direct dependency here, other steps do.
     type: enum
     enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
-    default: '1.15'
   org:
     type: string
     default: myhelix

--- a/src/jobs/test-parallel.yml
+++ b/src/jobs/test-parallel.yml
@@ -9,7 +9,6 @@ parameters:
       While we don't have a direct dependency here, other steps do.
     type: enum
     enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
-    default: '1.15'
   test_type:
     description: The test type to run.
     type: enum

--- a/src/jobs/test-v2.yml
+++ b/src/jobs/test-v2.yml
@@ -9,7 +9,6 @@ parameters:
       While we don't have a direct dependency here, other steps do.
     type: enum
     enum: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
-    default: '1.18'
   test_type:
     description: The test type to run.
     type: enum

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -9,7 +9,6 @@ parameters:
       While we don't have a direct dependency here, other steps do.
     type: enum
     enum: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
-    default: '1.15'
   test_type:
     description: The test type to run.
     type: enum


### PR DESCRIPTION
Ran into this with myhelix/genetic-counseling where some jobs didn't set the `golang-short-version` and defaulted to 1.18, resulting in version mismatches between our build and tests...

Removing the default forces all golang versions to be explicit.

This will likely break some repos' pipelines, but in a good way