### PR TITLE
[semver:minor] - Allow e2e tests with ginkgo

### DIFF
--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -19,7 +19,7 @@ parameters:
   test_type:
     description: The test type to run.
     type: enum
-    enum: ['acceptance', 'unit']
+    enum: ['acceptance', 'unit', 'e2e']
   ginkgo_params:
     type: string
     default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-fast --keep-going --race --trace --junit-report=report.xml --json-report=report.json --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s
@@ -63,6 +63,9 @@ steps:
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
           EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance"
+        elif [[ 'e2e' == "$TEST_TYPE" ]]; then
+          echo "Running E2E tests"
+          EXTRA_PARAMS="e2e"
         else
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"

--- a/src/commands/test-parallel-v2.yml
+++ b/src/commands/test-parallel-v2.yml
@@ -4,7 +4,7 @@ parameters:
   test_type:
     description: The test type to run.
     type: enum
-    enum: ['acceptance', 'unit']
+    enum: ['acceptance', 'unit', 'e2e']
   ginkgo_params:
     type: string
     default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-fast --keep-going --race --trace --junit-report=report.xml --json-report=report.json --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s
@@ -48,6 +48,9 @@ steps:
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
           EXTRA_PARAMS="--cover --coverprofile=cover.out --skip-package=acceptance"
+        elif [[ 'e2e' == "$TEST_TYPE" ]]; then
+          echo "Running E2E tests"
+          EXTRA_PARAMS="e2e"
         else
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"

--- a/src/commands/test-v2.yml
+++ b/src/commands/test-v2.yml
@@ -4,7 +4,7 @@ parameters:
   test_type:
     description: The test type to run.
     type: enum
-    enum: ['acceptance', 'unit']
+    enum: ['acceptance', 'unit', 'e2e']
   ginkgo_params:
     type: string
     default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-fast --keep-going --race --trace --junit-report=report.xml --json-report=report.json --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s
@@ -48,6 +48,9 @@ steps:
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
           EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance"
+        elif [[ 'e2e' == "$TEST_TYPE" ]]; then
+          echo "Running E2E tests"
+          EXTRA_PARAMS="e2e"
         else
           echo "Running acceptance tests"
           EXTRA_PARAMS="acceptance"

--- a/src/jobs/go-mod-ginkgo-v2-with-oidc.yml
+++ b/src/jobs/go-mod-ginkgo-v2-with-oidc.yml
@@ -23,7 +23,7 @@ parameters:
   test_type:
     description: The test type to run.
     type: enum
-    enum: ['acceptance', 'unit']
+    enum: ['acceptance', 'unit', 'e2e']
   ginkgo_params:
     type: string
     default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-fast --keep-going --race --trace --junit-report=report.xml --json-report=report.json --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s

--- a/src/jobs/go-mod-ginkgo-v2.yml
+++ b/src/jobs/go-mod-ginkgo-v2.yml
@@ -23,7 +23,7 @@ parameters:
   test_type:
     description: The test type to run.
     type: enum
-    enum: ['acceptance', 'unit']
+    enum: ['acceptance', 'unit', 'e2e']
   ginkgo_params:
     type: string
     default: -r --procs=4 --compilers=4 --randomize-all --randomize-suites --fail-fast --keep-going --race --trace --junit-report=report.xml --json-report=report.json --output-dir=test-results/ --timeout=5m --poll-progress-after=120s --poll-progress-interval=30s

--- a/src/jobs/test-v2.yml
+++ b/src/jobs/test-v2.yml
@@ -12,7 +12,7 @@ parameters:
   test_type:
     description: The test type to run.
     type: enum
-    enum: ['acceptance', 'unit']
+    enum: ['acceptance', 'unit', 'e2e']
   project_name:
     type: string
     description: "Project name, must match github repo name"


### PR DESCRIPTION
This PR modifies job for test with ginkgo to add 'e2e' to the enum of allowed values.