### PR TITLE
[semver:minior] - Fix ensure e2e skips for unit tests

### DIFF
--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -62,7 +62,7 @@ steps:
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance --skip-package=e2e"
+          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance,e2e"
         elif [[ 'e2e' == "$TEST_TYPE" ]]; then
           echo "Running E2E tests"
           EXTRA_PARAMS="e2e"

--- a/src/commands/ginkgo-v2.yml
+++ b/src/commands/ginkgo-v2.yml
@@ -62,7 +62,7 @@ steps:
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance"
+          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance --skip-package=e2e"
         elif [[ 'e2e' == "$TEST_TYPE" ]]; then
           echo "Running E2E tests"
           EXTRA_PARAMS="e2e"

--- a/src/commands/test-parallel-v2.yml
+++ b/src/commands/test-parallel-v2.yml
@@ -47,7 +47,7 @@ steps:
         EXTRA_PARMS=""
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="--cover --coverprofile=cover.out --skip-package=acceptance"
+          EXTRA_PARAMS="--cover --coverprofile=cover.out --skip-package=acceptance,e2e"
         elif [[ 'e2e' == "$TEST_TYPE" ]]; then
           echo "Running E2E tests"
           EXTRA_PARAMS="e2e"

--- a/src/commands/test-v2.yml
+++ b/src/commands/test-v2.yml
@@ -47,7 +47,7 @@ steps:
 
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance --skip-package=e2e"
+          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance,e2e"
         elif [[ 'e2e' == "$TEST_TYPE" ]]; then
           echo "Running E2E tests"
           EXTRA_PARAMS="e2e"

--- a/src/commands/test-v2.yml
+++ b/src/commands/test-v2.yml
@@ -47,7 +47,7 @@ steps:
 
         if [[ 'unit' == "$TEST_TYPE" ]]; then
           echo "Running all tests except acceptance tests"
-          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance"
+          EXTRA_PARAMS="--cover --coverprofile cover.out --skip-package=acceptance --skip-package=e2e"
         elif [[ 'e2e' == "$TEST_TYPE" ]]; then
           echo "Running E2E tests"
           EXTRA_PARAMS="e2e"


### PR DESCRIPTION
This PR ensures for unit tests a --skip-package=e2e gets added to ensure no other tests are ran.